### PR TITLE
Allow Custom Sub-components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 module.exports = {
   "stories": [
+    "../examples/**/*.stories.tsx",
     "../src/**/*.stories.mdx",
     "../src/**/*.stories.@(js|jsx|ts|tsx)"
   ],

--- a/examples/TableWithCustomRow/CustomRow.tsx
+++ b/examples/TableWithCustomRow/CustomRow.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement, useState } from 'react';
+import { Row } from 'react-table';
+
+import { TableRowProps } from '../../src/TableRow'
+
+export const CustomRow = <T extends Record<string, unknown>>(
+  props: TableRowProps<T>
+): ReactElement => {
+  const { row, editing, saveRow } = props;
+  const [data, setData] = useState(row);
+
+  return (
+    <tr {...row.getRowProps()}>
+      {row.cells.map((cell, index) => (
+        <td {...cell.getCellProps()} style={{ borderStyle: 'dotted', maxWidth: '100%', boxSizing: 'border-box'}}>
+          {cell.render('Cell')}
+        </td>
+      ))}
+    </tr>
+  )
+
+}

--- a/examples/TableWithCustomRow/CustomRow.tsx
+++ b/examples/TableWithCustomRow/CustomRow.tsx
@@ -3,14 +3,17 @@ import { Row } from 'react-table';
 
 import { TableRowProps } from '../../src/TableRow'
 
+interface CustomRowProps<T> extends TableRowProps<T> {
+  className: string,
+}
+
 export const CustomRow = <T extends Record<string, unknown>>(
-  props: TableRowProps<T>
+  props: CustomRowProps<T>
 ): ReactElement => {
-  const { row, editing, saveRow } = props;
-  const [data, setData] = useState(row);
+  const { className, row } = props;
 
   return (
-    <tr {...row.getRowProps()}>
+    <tr {...row.getRowProps()} className={className}>
       {row.cells.map((cell, index) => (
         <td {...cell.getCellProps()} style={{ borderStyle: 'dotted', maxWidth: '100%', boxSizing: 'border-box'}}>
           {cell.render('Cell')}

--- a/examples/TableWithCustomRow/Stars.tsx
+++ b/examples/TableWithCustomRow/Stars.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { StarIcon } from '@heroicons/react/outline'
+
+export type StarsProps = {
+  stars: number
+}
+
+export const Stars: React.FC<StarsProps> = ({ stars }) => {
+  return (
+    <>
+      <div style={{ maxWidth: '6rem', display: 'flex' }}>
+        {Array(stars).fill(<StarIcon />)}
+      </div>
+    </>
+  )
+}

--- a/examples/TableWithCustomRow/Stars.tsx
+++ b/examples/TableWithCustomRow/Stars.tsx
@@ -9,7 +9,7 @@ export const Stars: React.FC<StarsProps> = ({ stars }) => {
   return (
     <>
       <div style={{ maxWidth: '6rem', display: 'flex' }}>
-        {Array(stars).fill(<StarIcon />)}
+        {Array.from({ length: stars }, (_, i) => (<StarIcon key={i} />))}
       </div>
     </>
   )

--- a/examples/TableWithCustomRow/StyledCustomRow.tsx
+++ b/examples/TableWithCustomRow/StyledCustomRow.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { CustomRow } from './CustomRow'
+
+export const StyledCustomRow = styled(CustomRow)`
+  background:beige;
+  font-weight: bold;
+`

--- a/examples/TableWithCustomRow/TableWithCustomRow.stories.tsx
+++ b/examples/TableWithCustomRow/TableWithCustomRow.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { Column } from 'react-table'
+
+import { DataTable, DataTableProps } from '../../src/DataTable'
+import { Stars } from './Stars'
+import { CustomRow } from './CustomRow'
+
+export default {
+  title: 'examples/MoviesTable',
+  component: DataTable,
+} as Meta;
+
+type Movie = {
+  title: string
+  year: string
+  stars: React.ReactNode
+}
+
+type MovieData = Movie & {
+  subRows?: MovieData[]
+}
+
+const movieData = [
+  {
+    title: 'Tombstone',
+    year: '1993',
+    stars: <Stars stars={5} />
+  },
+]
+
+const columns: Column<MovieData>[] = [
+  {
+    Header: 'Title',
+    accessor: 'title',
+  },
+  {
+    Header: 'Year Released',
+    accessor: 'year',
+  },
+  {
+    Header: 'Rating',
+    accessor: 'stars',
+  },
+]
+
+const Template: Story<DataTableProps<MovieData>> = (args) => <DataTable<MovieData> {...args} />
+
+export const Basic = Template.bind({})
+
+Basic.args = {
+  data: movieData,
+  columns,
+  tableRow: CustomRow,
+  selectable: false,
+}

--- a/examples/TableWithCustomRow/TableWithCustomRow.stories.tsx
+++ b/examples/TableWithCustomRow/TableWithCustomRow.stories.tsx
@@ -4,7 +4,7 @@ import { Column } from 'react-table'
 
 import { DataTable, DataTableProps } from '../../src/DataTable'
 import { Stars } from './Stars'
-import { CustomRow } from './CustomRow'
+import { StyledCustomRow } from './StyledCustomRow'
 
 export default {
   title: 'examples/MoviesTable',
@@ -51,6 +51,6 @@ export const Basic = Template.bind({})
 Basic.args = {
   data: movieData,
   columns,
-  tableRow: CustomRow,
+  tableRow: StyledCustomRow,
   selectable: false,
 }

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -2,7 +2,7 @@ import React, {
   PropsWithChildren, ReactElement, useEffect, useMemo, useState,
 } from 'react';
 import {
-  Column, Hooks, Row, TableOptions, useRowSelect, useTable,
+  Column, HeaderGroup,  Hooks, Row, TableOptions, useRowSelect, useTable,
 } from 'react-table';
 import filter from 'lodash/filter';
 
@@ -27,6 +27,7 @@ export interface DataTableProps<T extends Record<string, unknown>>
     tableRow?: <T extends Record<string, unknown>>(
       props: TableRowProps<T>,
     ) => ReactElement,
+    disableToolbar: boolean,
 }
 
 export const DataTable = <T extends Record<string, unknown>>(
@@ -46,6 +47,7 @@ export const DataTable = <T extends Record<string, unknown>>(
     handleChange,
     selectable = true,
     tableRow,
+    disableToolbar = false,
   } = props;
 
   /** Table State */
@@ -146,28 +148,32 @@ export const DataTable = <T extends Record<string, unknown>>(
 
   return (
     <>
-    <TableThemeProvider>
-      <TableToolbar
-        canAdd={editing === null}
-        canDelete={selectedFlatRows.length > 0}
-        canEdit={selectedFlatRows.length === 1}
-        canReset={data.length !== initialData.length}
-        handleAdd={handleAdd}
-        handleDelete={handleDelete}
-        handleEdit={handleEdit}
-        handleReset={handleReset}
-      />
-        <StyledDataTable>
-          {/* The following divs are styled in DataTable/styled.tsx  */}
+      <TableThemeProvider>
+        {disableToolbar ? (
+          <TableToolbar
+          canAdd={editing === null}
+          canDelete={selectedFlatRows.length > 0}
+          canEdit={selectedFlatRows.length === 1}
+          canReset={data.length !== initialData.length}
+          handleAdd={handleAdd}
+          handleDelete={handleDelete}
+          handleEdit={handleEdit}
+          handleReset={handleReset}
+        />
+      ): null}
+
+      <StyledDataTable>
+        {/* The following divs are styled in DataTable/styled.tsx  */}
         <div>
           <div>
             <div>
               <table {...getTableProps()}>
                 <thead>
-                  {headerGroups.map((headerGroup, rowIndex) => (
+                  {headerGroups.map((headerGroup: HeaderGroup<T>, rowIndex: number) => (
                     <tr {...headerGroup.getHeaderGroupProps()}>
-                      {headerGroup.headers.map((column) => (
+                      {headerGroup.headers.map((column: Column<T>) => (
                         <th
+                          key={rowIndex}
                           {...column.getHeaderProps()}
                           scope="col"
                         >
@@ -192,15 +198,6 @@ export const DataTable = <T extends Record<string, unknown>>(
                           saveRow={saveRow}
                         />
                       )
-
-                      return (
-                        <TableRow<T>
-                          key={row.index}
-                          row={row}
-                          editing={editing}
-                          saveRow={saveRow}
-                        />
-                      );
                     })
                   }
                 </tbody>

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -10,7 +10,7 @@ import { TableThemeProvider } from '../Theme'
 import { StyledDataTable } from './styled'
 
 import { TableToolbar } from '../TableToolbar';
-import { TableRow } from '../TableRow';
+import { TableRow, TableRowProps } from '../TableRow';
 import { EditableCell } from '../TableCell';
 import { selectionHook } from '../utils';
 
@@ -24,6 +24,9 @@ export interface DataTableProps<T extends Record<string, unknown>>
     name?: string
     handleChange: (data: T[]) => void
     selectable?: boolean
+    tableRow?: <T extends Record<string, unknown>>(
+      props: TableRowProps<T>,
+    ) => ReactElement,
 }
 
 export const DataTable = <T extends Record<string, unknown>>(
@@ -42,6 +45,7 @@ export const DataTable = <T extends Record<string, unknown>>(
     defaultItem,
     handleChange,
     selectable = true,
+    tableRow,
   } = props;
 
   /** Table State */
@@ -138,6 +142,8 @@ export const DataTable = <T extends Record<string, unknown>>(
     setInitialRender(false);
   }, [data, editing]);
 
+  const TableRowRender = tableRow ? tableRow : TableRow
+
   return (
     <>
     <TableThemeProvider>
@@ -175,8 +181,18 @@ export const DataTable = <T extends Record<string, unknown>>(
                   {...getTableBodyProps()}
                 >
                   {
-                    rows.map((row) => {
+                    rows.map((row: Row<T>) => {
                       prepareRow(row);
+
+                      return (
+                        <TableRowRender<T>
+                          key={row.index}
+                          row={row}
+                          editing={editing}
+                          saveRow={saveRow}
+                        />
+                      )
+
                       return (
                         <TableRow<T>
                           key={row.index}


### PR DESCRIPTION
This PR adds:
* disableToolbar DataTable prop - defaults to false
* Option to override the default Row component using the tableRow optional prop