### PR TITLE
Input type option on columns array

### DIFF
--- a/examples/CellWithInputTypes/CellWithInputTypes.stories.tsx
+++ b/examples/CellWithInputTypes/CellWithInputTypes.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { ColumnInterface } from 'react-table'
+
+import { DataTable, DataTableProps } from '../../src/DataTable'
+
+export default {
+  title: 'examples/CellWithInputTypes',
+  component: DataTable,
+} as Meta
+
+type CarModel = 'Ford' | 'Acura' | 'Honda'
+type CarColor = 'Red' | 'Black' | 'White' | 'Blue'
+
+type Car = {
+  model: CarModel
+  year: number
+  color: CarColor
+  delivery: string
+  quantity: number
+}
+
+type CarData = Car & {
+  subRows?: CarData[]
+}
+
+const carData = [
+  {
+    model: '1',
+    year: 2019,
+    color: 'Red',
+    delivery: '2021-01-20',
+    quantity: 5,
+  },
+  {
+    model: '3',
+    year: 2020,
+    color: 'Blue',
+    delivery: '2021-05-01',
+    quantity: 5,
+  }
+]
+
+const columns: ColumnInterface<CarData>[] = [
+  {
+    Header: 'Model',
+    accessor: 'model',
+    options: [
+      {
+        label: 'Acura',
+        value: '1',
+      },
+      {
+        label: 'Ford',
+        value: '2',
+      },
+      {
+        label: 'Honda',
+        value: '3',
+      }
+    ]
+  },
+  {
+    Header: 'Year',
+    accessor: 'year',
+  },
+  {
+    Header: 'Color',
+    accessor: 'color',
+  },
+  {
+    Header: 'Delivery',
+    accessor: 'delivery',
+    inputType: 'date',
+  },
+  {
+    Header: 'Quantity',
+    accessor: 'quantity',
+    inputType: 'number',
+  },
+]
+
+const defaultItem = {
+  model: '',
+  year: '',
+  color: '',
+  delivery: '',
+  quantity: '',
+}
+
+const handleChange = (newData: CarData) => {
+  console.log(newData)
+}
+
+const Template: Story<DataTableProps < CarData >> = (args) => <DataTable<CarData> {...args} />
+
+export const Basic = Template.bind({})
+
+Basic.args = {
+  data: carData,
+  columns,
+  defaultItem,
+  selectable: true,
+  handleChange,
+}

--- a/src/TableCell/index.tsx
+++ b/src/TableCell/index.tsx
@@ -30,7 +30,7 @@ const isSelectOption = (value: OptionTypeBase | string | number): value is Optio
 export const EditableCell: React.FC<EditableCellProps> = ({
   value: initialValue,
   // row: { index },
-  column: { id, options },
+  column: { id, options, inputType },
   isEditable,
   onChange,
   index,
@@ -100,6 +100,7 @@ export const EditableCell: React.FC<EditableCellProps> = ({
         className="border-b border-blue-400"
         value={value || ''}
         onChange={onLocalChange}
+        type={inputType ? inputType : 'text'}
         /*
           The focus needs to be on the first input of the Row, 
           but datatable has two options, when the select option 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ declare module 'react-table' {
     UseSortByColumnOptions<D> {
     align?: string,
     options?: OptionTypeBase[]
+    inputType?: string,
   }
 
   export interface ColumnInstance<D extends Record<string, unknown> = Record<string, unknown>>


### PR DESCRIPTION
- The input type could be set on the columns array. The default input type is 'text'. 

Fixes https://github.com/CrossroadsCX/datatable/issues/45