### PR TITLE
Update pagination style to match new designs

### DIFF
--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -55,6 +55,7 @@ export interface DataTableProps<T extends Record<string, unknown>>
     handleFetchData?: (args: HandleFetchDataArgs<T>) => Promise<void>
     stickyHeader?: boolean,
     tableRef?: React.RefObject<HTMLTableElement>,
+    totalRows : number
     // Component overrides
     tableRow?: <T extends Record<string, unknown>>(
       props: TableRowProps<T>,
@@ -89,6 +90,7 @@ export const DataTable = <T extends Record<string, unknown>>(
     paginated = false,
     selectable = false,
     tableRef = useRef<HTMLTableElement>(null),
+    totalRows,
     tableRow,
     tableToolbar,
     theme = defaultTheme,
@@ -101,7 +103,7 @@ export const DataTable = <T extends Record<string, unknown>>(
   const [tableData, setData] = useState<T[]>(data)
   const resetTable = handleFetchData ? false : true
   const [isNewRowAfterSave, setIsNewRowAfterSave] =  useState<boolean>(false)
-  const [totalResults, setTotalResults] = useState<number>(0)
+  const [totalResults] = useState<number>(totalRows || data.length)
   /*
    *  Selectable Options
    *    Add checkbox inputs in the header / rows with selectionHook
@@ -225,7 +227,6 @@ export const DataTable = <T extends Record<string, unknown>>(
   // If the incoming data changes, override the table data
   useEffect(() => {
     setData(data)
-    setTotalResults(data.length)
     if(isEditing){
       if(data.length === 0){
         handleAdd()

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -101,7 +101,7 @@ export const DataTable = <T extends Record<string, unknown>>(
   const [tableData, setData] = useState<T[]>(data)
   const resetTable = handleFetchData ? false : true
   const [isNewRowAfterSave, setIsNewRowAfterSave] =  useState<boolean>(false)
-
+  const [totalResults, setTotalResults] = useState<number>(0)
   /*
    *  Selectable Options
    *    Add checkbox inputs in the header / rows with selectionHook
@@ -225,6 +225,7 @@ export const DataTable = <T extends Record<string, unknown>>(
   // If the incoming data changes, override the table data
   useEffect(() => {
     setData(data)
+    setTotalResults(data.length)
     if(isEditing){
       if(data.length === 0){
         handleAdd()
@@ -261,6 +262,7 @@ export const DataTable = <T extends Record<string, unknown>>(
     nextPage,
     previousPage,
     setPageSize,
+    totalResults,
     async: handleFetchData ? true : false,
   }
 
@@ -368,8 +370,7 @@ export const DataTable = <T extends Record<string, unknown>>(
 
   const PaginatedTable = () => (
     <>
-      <Table />
-      <Pagination {...paginationProps} />
+      <Pagination {...paginationProps} table={ <Table />} />
     </>
   )
 

--- a/src/Pagination/index.tsx
+++ b/src/Pagination/index.tsx
@@ -1,73 +1,106 @@
 import React from 'react'
-import { StyledPagination } from './styled'
-import {
-  ArrowSmRightIcon, ArrowSmLeftIcon, ChevronRightIcon, ChevronLeftIcon,
-} from '@heroicons/react/outline';
+import { StyledPaginationBottom, StyledPaginationTop } from './styled'
+import { ChevronRightIcon, ChevronLeftIcon } from '@heroicons/react/outline';
 
 export type PaginationProps = {
-    gotoPage: (numberPage: number) => void, 
-    canPreviousPage: boolean,
-    previousPage: () => void,
-    canNextPage: boolean,
-    nextPage: () => void,
-    pageIndex: number,
-    pageOptions: number[],
-    pageSize: number, 
-    pageCount: number,
-    setPageSize: (numberSize: number) => void,
+  gotoPage: (numberPage: number) => void,
+  canPreviousPage: boolean,
+  previousPage: () => void,
+  canNextPage: boolean,
+  nextPage: () => void,
+  pageIndex: number,
+  pageOptions: number[],
+  pageSize: number,
+  pageCount: number,
+  setPageSize: (numberSize: number) => void,
+  totalResults: number,
+  table: React.ReactElement
 }
 
 export const Pagination: React.FC<PaginationProps> = ({
-    gotoPage,
-    canPreviousPage,
-    previousPage,
-    canNextPage,
-    nextPage,
-    pageIndex,
-    pageOptions, 
-    pageSize,
-    pageCount,
-    setPageSize
-  }) => {
+  gotoPage,
+  canPreviousPage,
+  previousPage,
+  canNextPage,
+  nextPage,
+  pageIndex,
+  pageOptions,
+  pageSize,
+  pageCount,
+  setPageSize,
+  totalResults,
+  table,
+}) => {
+  //Get the difference between the total results and the max results on the last page
+  const difference = - totalResults - (pageCount*pageSize)
+  // Fuction to get the range of the showing results
+  const getActualResultsRange = () => {
+    return (pageIndex + 1 == pageCount ? Math.abs((pageCount * pageSize + difference )) : (pageIndex + 1) * pageSize )
+  }
 
-    return (
-        <StyledPagination className="pagination">
-          <div>
-              <ChevronLeftIcon 
-                onClick={() => previousPage()} 
-                className={`${canPreviousPage ? 'enabled': ''}`}              
-              />
-            </div>
-            <div>
-              <span>
-                {` Previous`}
-              </span>
-              <span>
-                <input
-                  type="number"
-                  defaultValue={pageIndex + 1}
-                  min={1}
-                  max={pageOptions.length}
-                  onChange={e => {
-                      const page = e.target.value ? Number(e.target.value) - 1 : 0
-                      gotoPage(page)
-                    }}
-                  style={{ width: '35px', height: '15px', marginLeft:'8px', marginRight:'8px' }}
-                />
-              </span>
-              <span>
-                out of {pageOptions.length}
-              </span>
-              <span>
-                {` Next`}
-              </span>
-            </div>
-            <div>
-              <ChevronRightIcon 
-                onClick={() => nextPage()} 
-                className={`${canNextPage ? 'enabled': ''}`}
-              />
-            </div>
-          </StyledPagination>
-      )
+  return (
+    <>
+      <StyledPaginationTop className="pagination">
+        <div>
+          {`Showing ${(pageIndex * pageSize) + 1} -  ${getActualResultsRange()} of ${totalResults} results`}
+        </div>
+        <div>
+          <span>
+            {`Results per page `}
+          </span>
+          <select
+            value={pageSize}
+            onChange={e => {
+              setPageSize(Number(e.target.value))
+            }}
+          >
+            {[10, 20, 30, 40, 50].map(pageSize => (
+              <option key={pageSize} value={pageSize}>
+                {pageSize}
+              </option>
+            ))}
+          </select>
+        </div>
+      </StyledPaginationTop>
+      {table}
+      <StyledPaginationBottom className="pagination">
+        <div>
+          <ChevronLeftIcon
+            onClick={() => previousPage()}
+            className={`${canPreviousPage ? 'enabled' : ''}`}
+          />
+        </div>
+        <div>
+          <span>
+            {` Previous`}
+          </span>
+          <span>
+            <input
+              type="number"
+              defaultValue={pageIndex + 1}
+              min={1}
+              max={pageOptions.length}
+              onChange={e => {
+                const page = e.target.value ? Number(e.target.value) - 1 : 0
+                gotoPage(page)
+              }}
+              style={{ width: '35px', height: '15px', marginLeft: '8px', marginRight: '8px' }}
+            />
+          </span>
+          <span>
+            out of {pageOptions.length}
+          </span>
+          <span>
+            {` Next`}
+          </span>
+        </div>
+        <div>
+          <ChevronRightIcon
+            onClick={() => nextPage()}
+            className={`${canNextPage ? 'enabled' : ''}`}
+          />
+        </div>
+      </StyledPaginationBottom>
+    </>
+  )
 }

--- a/src/Pagination/index.tsx
+++ b/src/Pagination/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StyledPagination } from './styled'
 import {
-  ArrowSmRightIcon, ArrowSmLeftIcon, ChevronDoubleRightIcon, ChevronDoubleLeftIcon,
+  ArrowSmRightIcon, ArrowSmLeftIcon, ChevronRightIcon, ChevronLeftIcon,
 } from '@heroicons/react/outline';
 
 export type PaginationProps = {
@@ -32,54 +32,39 @@ export const Pagination: React.FC<PaginationProps> = ({
 
     return (
         <StyledPagination className="pagination">
+          <div>
+              <ChevronLeftIcon 
+                onClick={() => previousPage()} 
+                className={`${canPreviousPage ? 'enabled': ''}`}              
+              />
+            </div>
             <div>
               <span>
-                Page{' '}
-                <strong>
-                  {pageIndex + 1} of {pageOptions.length}
-                </strong>{' '}
+                {` Previous`}
               </span>
               <span>
-                | Go to page:{' '}
                 <input
                   type="number"
                   defaultValue={pageIndex + 1}
+                  min={1}
+                  max={pageOptions.length}
                   onChange={e => {
                       const page = e.target.value ? Number(e.target.value) - 1 : 0
                       gotoPage(page)
                     }}
-                  style={{ width: '100px' }}
+                  style={{ width: '35px', height: '15px', marginLeft:'8px', marginRight:'8px' }}
                 />
-              </span>{' '}
-              <select
-                value={pageSize}
-                onChange={e => {
-                  setPageSize(Number(e.target.value))
-                }}
-              >
-                {[10, 20, 30, 40, 50].map(pageSize => (
-                  <option key={pageSize} value={pageSize}>
-                    Show {pageSize}
-                  </option>
-                ))}
-              </select>
-
+              </span>
+              <span>
+                out of {pageOptions.length}
+              </span>
+              <span>
+                {` Next`}
+              </span>
             </div>
             <div>
-              <ChevronDoubleLeftIcon 
-                onClick={() => gotoPage(0)} 
-                className={`${canPreviousPage ? 'enabled': ''}`}
-              />
-              <ArrowSmLeftIcon 
-                onClick={() => previousPage()} 
-                className={`${canPreviousPage ? 'enabled': ''}`}              
-              />
-              <ArrowSmRightIcon 
+              <ChevronRightIcon 
                 onClick={() => nextPage()} 
-                className={`${canNextPage ? 'enabled': ''}`}
-              />
-              <ChevronDoubleRightIcon 
-                onClick={() => gotoPage(pageCount - 1)} 
                 className={`${canNextPage ? 'enabled': ''}`}
               />
             </div>

--- a/src/Pagination/index.tsx
+++ b/src/Pagination/index.tsx
@@ -32,6 +32,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   table,
 }) => {
   //Get the difference between the total results and the max results on the last page
+  console.log(totalResults)
   const difference = - totalResults - (pageCount*pageSize)
   // Fuction to get the range of the showing results
   const getActualResultsRange = () => {

--- a/src/Pagination/styled.tsx
+++ b/src/Pagination/styled.tsx
@@ -4,13 +4,13 @@ export const StyledPagination = styled.div`
   display: flex;
   width:100%;
   align-items: center;
-  justify-content: space-between;
+  justify-content: end;
   margin-top: 10px;
+  color: ${props => props.theme.colors.gray};
   svg {
     height: 1.5rem;
     width: 1.5rem;
     padding: 5px;
-    border: 1px solid ${props => props.theme.colors.lightGray};
     color: ${props => props.theme.colors.lightGray};
 
     &.enabled {
@@ -18,8 +18,7 @@ export const StyledPagination = styled.div`
       cursor: pointer;
 
       &:hover {
-        color: ${props => props.theme.colors.lightGray};
-        background:  ${props => props.theme.colors.gray};
+        color: ${props => props.theme.colors.darkGray};
       }
     }
   }

--- a/src/Pagination/styled.tsx
+++ b/src/Pagination/styled.tsx
@@ -1,6 +1,26 @@
 import styled from 'styled-components'
 
-export const StyledPagination = styled.div`
+export const StyledPaginationTop = styled.div`
+  display: flex;
+  width:100%;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  color: ${props => props.theme.colors.gray};
+  select {
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 15px;
+    padding-top: 5px;
+    border-radius: 5px;
+    background-color: white;
+    width: 50px;
+    height: '15px'
+    border-color: ${props => props.theme.colors.lightGray};
+  }
+`
+
+export const StyledPaginationBottom = styled.div`
   display: flex;
   width:100%;
   align-items: center;
@@ -21,14 +41,6 @@ export const StyledPagination = styled.div`
         color: ${props => props.theme.colors.darkGray};
       }
     }
-  }
-  select {
-    padding-bottom: 5px;
-    padding-left: 5px;
-    padding-right: 15px;
-    padding-top: 5px;
-    border-radius: 5px;
-    border-color: ${props => props.theme.colors.lightGray};
   }
   input{
     padding: 5px;


### PR DESCRIPTION
The pagination style have been updated to match the new designs:

- `Pagination` component now works as a wrapper
- Added `totalResults` and `table` props to `Pagination`
- Added `getActualResults` function to `Pagination`
- Updated `Pagination/index`
- Updated `Pagination/styled`
- `StyledPagination` splited to `Bottom` and `Top`
- `DataTable/index` updated to new `Pagination` props